### PR TITLE
Dockerized build scripts for the master branch

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -40,4 +40,5 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          environment: ${{ github.event.inputs.environment }}
           workingDirectory: "_site"

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build-and-deploy:
-    name: Build and Deploy to Netlify
+    name: Build and Deploy to Cloudflare
     runs-on: ubuntu-latest
     
     # 2. Use the environment input to set the environment
@@ -35,12 +35,9 @@ jobs:
         run: |
           ./scripts/build.sh
 
-      # 5. Deploy to Netlify using the Netlify CLI Action
-      - name: Deploy to Netlify
-        uses: netlify/actions/cli@master
+      # 5. Deploy to Cloudflare using the Cloudflare Wrangler Action
+      - name: Deploy
+        uses: cloudflare/wrangler-action@v3
         with:
-          # --prod does a production deploy
-          args: deploy --dir=_site --prod
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: "_site"

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -12,7 +12,7 @@ on:
       environment:
         description: "Environment to deploy to"
         required: false
-        default: "Dev"
+        default: "development"
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,4 +1,4 @@
-name: Manual Build & Deploy to Netlify (Dev)
+name: Build & Deploy to Cloudflare
 
 on:
   # 1. Manual trigger via the Actions tab

--- a/.github/workflows/deploy-netlify.yml
+++ b/.github/workflows/deploy-netlify.yml
@@ -1,4 +1,4 @@
-name: Manual Build & Deploy to Netlify (Dev)
+name: Build & Deploy to Netlify
 
 on:
   # 1. Manual trigger via the Actions tab

--- a/.github/workflows/deploy-netlify.yml
+++ b/.github/workflows/deploy-netlify.yml
@@ -12,7 +12,7 @@ on:
       environment:
         description: "Environment to deploy to"
         required: false
-        default: "Dev"
+        default: "development"
 
 jobs:
   build-and-deploy:

--- a/Dockerfiles/Dockerfile.bundle
+++ b/Dockerfiles/Dockerfile.bundle
@@ -1,0 +1,14 @@
+FROM jekyll/jekyll:3.8.6
+
+# Create a working directory.
+WORKDIR /srv/jekyll
+
+# Copy dependency files first for caching.
+COPY Gemfile ./
+
+# Make files be owned by jekyll user.
+RUN chown -R jekyll:jekyll /srv/jekyll
+
+# Update the bundle and add the current platform lock.
+RUN bundle lock
+

--- a/Dockerfiles/Dockerfile.bundle
+++ b/Dockerfiles/Dockerfile.bundle
@@ -1,4 +1,4 @@
-FROM jekyll/jekyll:3.8.6
+FROM jekyll/jekyll:4.0
 
 # Create a working directory.
 WORKDIR /srv/jekyll

--- a/Dockerfiles/Dockerfile.jekyll
+++ b/Dockerfiles/Dockerfile.jekyll
@@ -1,9 +1,6 @@
 # Use Ruby 3.1 series on Alpine.
 FROM ruby:3.1-alpine
 
-# Update RubyGems system.
-# RUN gem update --system 3.3.22
-
 # Install system dependencies.
 # (Node.js is here for asset compilation, adjust as needed.)
 RUN apk update && apk add --no-cache \
@@ -12,7 +9,7 @@ RUN apk update && apk add --no-cache \
     libffi-dev
 
 # Install bundler if it’s not already available.
-# RUN gem install bundler -v 2.0.2
+RUN gem install bundler -v 2.3.25
 
 # Set working directory.
 WORKDIR /srv/jekyll

--- a/Dockerfiles/Dockerfile.jekyll
+++ b/Dockerfiles/Dockerfile.jekyll
@@ -1,5 +1,5 @@
-# Use Ruby 2.6.3 on Alpine.
-FROM ruby:2.6.3-alpine
+# Use Ruby 3.1 series on Alpine.
+FROM ruby:3.1-alpine
 
 # Update RubyGems system.
 # RUN gem update --system 3.3.22

--- a/Dockerfiles/Dockerfile.jekyll
+++ b/Dockerfiles/Dockerfile.jekyll
@@ -1,0 +1,34 @@
+# Use Ruby 2.6.3 on Alpine.
+FROM ruby:2.6.3-alpine
+
+# Update RubyGems system.
+RUN gem update --system 3.3.22
+
+# Install system dependencies.
+# (Node.js is here for asset compilation, adjust as needed.)
+RUN apk update && apk add --no-cache \
+    build-base \
+    nodejs \
+    libffi-dev
+
+# Install bundler if it’s not already available.
+RUN gem install bundler -v 2.0.2
+
+# Set working directory.
+WORKDIR /srv/jekyll
+
+# Copy project files (so that dependencies are installed during image build).
+# When running interactively you will mount your project folder over this.
+COPY . .
+
+# Install Ruby dependencies as specified in the Gemfile.
+RUN bundle install
+
+# Expose the default Jekyll port.
+EXPOSE 4000
+
+ENV JEKYLL_ENV=docker
+
+# Run the Jekyll server with incremental rebuilds and bind to localhost.
+CMD ["bundle", "exec", "jekyll", "serve", "--incremental", "--host", "0.0.0.0", "--config", "_config_docker.yml"]
+

--- a/Dockerfiles/Dockerfile.jekyll
+++ b/Dockerfiles/Dockerfile.jekyll
@@ -16,10 +16,13 @@ WORKDIR /srv/jekyll
 
 # Copy project files (so that dependencies are installed during image build).
 # When running interactively you will mount your project folder over this.
-COPY . .
+COPY Gemfile Gemfile.lock ./
 
 # Install Ruby dependencies as specified in the Gemfile.
 RUN bundle install
+
+# Copy the rest of the project files.
+COPY . .
 
 # Expose the default Jekyll port.
 EXPOSE 4000

--- a/Dockerfiles/Dockerfile.jekyll
+++ b/Dockerfiles/Dockerfile.jekyll
@@ -2,7 +2,7 @@
 FROM ruby:2.6.3-alpine
 
 # Update RubyGems system.
-RUN gem update --system 3.3.22
+# RUN gem update --system 3.3.22
 
 # Install system dependencies.
 # (Node.js is here for asset compilation, adjust as needed.)
@@ -12,7 +12,7 @@ RUN apk update && apk add --no-cache \
     libffi-dev
 
 # Install bundler if it’s not already available.
-RUN gem install bundler -v 2.0.2
+# RUN gem install bundler -v 2.0.2
 
 # Set working directory.
 WORKDIR /srv/jekyll

--- a/Dockerfiles/Dockerfile.jekyll
+++ b/Dockerfiles/Dockerfile.jekyll
@@ -14,14 +14,14 @@ RUN gem install bundler -v 2.3.25
 # Set working directory.
 WORKDIR /srv/jekyll
 
-# Copy project files (so that dependencies are installed during image build).
-# When running interactively you will mount your project folder over this.
+# Copy Gemfiles (so that dependencies are installed during image build).
 COPY Gemfile Gemfile.lock ./
 
 # Install Ruby dependencies as specified in the Gemfile.
 RUN bundle install
 
 # Copy the rest of the project files.
+# When running interactively you will mount your project folder over this.
 COPY . .
 
 # Expose the default Jekyll port.

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 # A sample Gemfile
 source "https://rubygems.org"
 
-gem "jekyll"
+ruby '~> 3.1.1'
+gem "jekyll", "~> 4.3.3"
 
 gem "jekyll-sass-converter", "~> 2.0"
 gem "webrick", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,17 +4,17 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     colorator (1.1.0)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.16.3)
+    ffi (1.17.1-x86_64-linux-musl)
     forwardable-extended (2.6.0)
     http_parser.rb (0.8.0)
-    i18n (1.14.5)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.3)
+    jekyll (4.3.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -34,8 +34,8 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.4.0)
-      rexml
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
@@ -49,26 +49,26 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.2)
-      strscan
-    rouge (4.3.0)
+    rexml (3.4.0)
+    rouge (4.5.1)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
-    strscan (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    unicode-display_width (2.5.0)
-    webrick (1.8.1)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
 
 PLATFORMS
-  aarch64-linux-gnu
-  ruby
+  x86_64-linux-musl
 
 DEPENDENCIES
-  jekyll
+  jekyll (~> 4.3.3)
   jekyll-sass-converter (~> 2.0)
   webrick (~> 1.8)
 
+RUBY VERSION
+   ruby 3.1.1p18
+
 BUNDLED WITH
-   2.1.4
+   2.3.25

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
+    ffi (1.17.1-aarch64-linux-musl)
     ffi (1.17.1-x86_64-linux-musl)
     forwardable-extended (2.6.0)
     http_parser.rb (0.8.0)
@@ -60,6 +61,7 @@ GEM
     webrick (1.9.1)
 
 PLATFORMS
+  aarch64-linux-musl
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/_config_docker.yml
+++ b/_config_docker.yml
@@ -1,0 +1,11 @@
+# Site settings
+title: argmin gravitas
+fmtTitle: argmin gravitas
+email: g@gleech.org  
+baseurl: "" # the subpath of your site, e.g. /blog/
+url: http://localhost:4000 # the base hostname & protocol for your site
+github_username:  g-leech
+highlighter: none
+
+# Build settings
+markdown: kramdown

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+echo "Building Docker image for static site generation..."
+docker build --platform=linux/amd64 -t argmin-gravitas/jekyll-build -f Dockerfiles/Dockerfile.jekyll .
+
+echo "Generating static site..."
+# Mount your local "./_site" directory to the container's /srv/jekyll/_site directory.
+mkdir -p _site
+docker run --platform=linux/amd64 -v "$(pwd)/_site:/srv/jekyll/_site" argmin-gravitas/jekyll-build bundle exec jekyll build
+
+echo "Site built successfully into the ./_site directory."

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,11 +2,11 @@
 set -e
 
 echo "Building Docker image for static site generation..."
-docker build --platform=linux/amd64 -t argmin-gravitas/jekyll-build -f Dockerfiles/Dockerfile.jekyll .
+docker build --platform=linux/amd64 -t argmin-gravitas/jekyll-dev -f Dockerfiles/Dockerfile.jekyll .
 
 echo "Generating static site..."
 # Mount your local "./_site" directory to the container's /srv/jekyll/_site directory.
 mkdir -p _site
-docker run --platform=linux/amd64 -v "$(pwd)/_site:/srv/jekyll/_site" argmin-gravitas/jekyll-build bundle exec jekyll build
+docker run --platform=linux/amd64 -v "$(pwd)/_site:/srv/jekyll/_site" argmin-gravitas/jekyll-dev bundle exec jekyll build
 
 echo "Site built successfully into the ./_site directory."

--- a/scripts/bundle-lock.sh
+++ b/scripts/bundle-lock.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+# Define image name and Dockerfile path.
+IMAGE_NAME="gemfile_updater"
+DOCKERFILE="Dockerfiles/Dockerfile.bundle"
+
+echo "Building the Docker image"
+docker build -t ${IMAGE_NAME} -f ${DOCKERFILE} .
+
+# Create a container from the builder image.
+CONTAINER_ID=$(docker create ${IMAGE_NAME})
+
+# Copy the Gemfile.lock from the container to the host.
+echo "Copying updated Gemfile.lock from container (${CONTAINER_ID})..."
+docker cp "${CONTAINER_ID}:/srv/jekyll/Gemfile.lock" ./Gemfile.lock
+
+# Clean up the temporary container.
+docker rm ${CONTAINER_ID} > /dev/null
+
+echo "Updated Gemfile.lock has been copied to the host."

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+echo "Building Docker image for Jekyll development..."
+docker build -t argmin-gravitas/jekyll-dev -f Dockerfiles/Dockerfile.jekyll .
+
+echo "Running Docker container with live file editing enabled..."
+# The -v flag mounts the current directory (source code) into /srv/jekyll in the container.
+docker run -p 4000:4000 -v "$(pwd)":/srv/jekyll argmin-gravitas/jekyll-dev

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "Building Docker image for Jekyll development..."
-docker build --progress plain -t argmin-gravitas/jekyll-dev -f Dockerfiles/Dockerfile.jekyll .
+docker build -t argmin-gravitas/jekyll-dev -f Dockerfiles/Dockerfile.jekyll .
 
 echo "Running Docker container with live file editing enabled..."
 # The -v flag mounts the current directory (source code) into /srv/jekyll in the container.

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "Building Docker image for Jekyll development..."
-docker build -t argmin-gravitas/jekyll-dev -f Dockerfiles/Dockerfile.jekyll .
+docker build --progress plain -t argmin-gravitas/jekyll-dev -f Dockerfiles/Dockerfile.jekyll .
 
 echo "Running Docker container with live file editing enabled..."
 # The -v flag mounts the current directory (source code) into /srv/jekyll in the container.


### PR DESCRIPTION
This is pretty much the same as we did for Jooda, but for the versions used in the master branch. Specifically,

* Targeting jekyll 4+
* Targeting ruby 3+